### PR TITLE
Do not use es6 'default function parameters' so we can uglify

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -38,7 +38,10 @@ function _valueToString (value) {
  * @param {string[]} path - An array of property names to traverse one-by-one
  * @param {number} [pathIndex=0] - The current index in the path array
  */
-function _recursivePathResolver(scope, path, pathIndex = 0) {
+function _recursivePathResolver(scope, path, pathIndex) {
+  // set init defaults
+  pathIndex = pathIndex || 0;
+  
   if (typeof scope !== 'object' || scope === null || scope === undefined) {
     return '';
   }
@@ -76,7 +79,11 @@ function defaultResolver(varName, view) {
  *        be stringified by JSON.
  *        In case of a JSON stringify error the result will look like "{...}".
  */
-function render (template, view = {}, resolver = defaultResolver) {
+function render (template, view, resolver) {
+  // set init defaults
+  view = view || {};
+  resolver = resolver || defaultResolver;
+  
   // don't touch the template if it is not a string
   if (typeof template !== 'string') {
     return template;


### PR DESCRIPTION
I'm currently using a preconfigured webpack i.e. **create-react-app**, **next.js** which doesn't allow transpiling from _node_modules_ dependencies directly by default unless you eject. This PR moves setting of default argument values inside function bodies.