### PR TITLE
Expose a commonjs browser distribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
-## Unrelease
+## Unreleased
 
 - Support [optional chaining syntax](https://github.com/tc39/proposal-optional-chaining)
 - Support comments: `{{! ...}}` like MustacheJS
 - Reenable tests/ for mustache compatibility and add relevant options
 - Add a string literal tag function (generic render)
 - Add the possibility to process variable names before and after they are resolved using `get()`. This can allow HTML escaping for example.
+- Expose a CommonJS build for the browser limited to ECMAScript 5 features.
 
 ## 6.0.0
 
@@ -24,7 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 BREAKING CHANGES:
 - **The biggest change is that if you used `compile()` in version 5, it returned a function but since version 6, it returns an object that _has_ a `render()` function**
-- The behaviour of the resolver function has changed: In v5 if the resolver threw an error we fell back to the standard `.get()` functionality but v6 just throws that error in an effort to make debugging easier. 
+- The behaviour of the resolver function has changed: In v5 if the resolver threw an error we fell back to the standard `.get()` functionality but v6 just throws that error in an effort to make debugging easier.
 - We don't use default exports anymore so `const render = require('micromustache/render')`
   should be refactored to `const { render } = require('micromustache')`
 - Now the compiler returns a renderer object with a render() function

--- a/package.json
+++ b/package.json
@@ -44,8 +44,9 @@
   "scripts": {
     "clean": "rimraf dist",
     "build:amd": "tsc -p tsconfig-amd.json",
+    "build:commonjs": "tsc -p tsconfig-commonjs.json",
     "build:node": "tsc -p tsconfig-node.json",
-    "build": "npm run clean && npm run build:amd && npm run build:node",
+    "build": "npm run clean && npm run build:amd && npm run build:node && npm run build:commonjs",
     "docs": "typedoc src/",
     "lint": "tslint -p .",
     "lint:fix": "npm run lint -- --fix",

--- a/tsconfig-commonjs.json
+++ b/tsconfig-commonjs.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["es2015"],
+    "module": "commonjs",
+    "outDir": "dist/browser/commonjs"
+  }
+}


### PR DESCRIPTION
# Why

Many web apps are built using Webpack and transpiled using babel. They
do this to bundle assets and to transpile newer JavaScript features for
older browsers. For this reason ES6 features are commonly transpiled to
ES5.

For efficiency purposes, the build process of these web apps is commonly
excluding anything in `node_modules`. When babel has to run over
anything within `node_modules`, then the whole build process is commonly
a lot slower.

# What

In order to ensure that projects set up like this can make use of
micromustache, the library should expose a commonjs bundled variant with
the ES5 feature set.

This makes it a lot easier for these projects, because they can just
import micromustache like this and be done:

```javascript
import { renderFn, get } from 'micromustache/dist/browser/commonjs';
```

# Verification

I have executed this locally and copied the build artifacts to our
project. The browser commonjs variant can be used without any problems
in these cases.