### PR TITLE
feat: reduce the size of the package deployed to NPM

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,2 @@
-.travis.yml
-perf/
-examples/
+*
+!dist/**/*

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "module": "dist/micromustache.mjs",
   "directories": {
     "bin": "./bin",
+    "example": "examples",
     "lib": "./dist"
   },
   "engines": {


### PR DESCRIPTION
NPM deployed package as of v7.0.0 is 2.6MB unpacked.
This is clearly not acceptable since this is a tiny package with no dependencies.
This PR only whitelists the dist/ folder